### PR TITLE
[IDP-3261] Use older Ubuntu agent in publish workflow due to lack of support for older MongoDB versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    # As of 18/12/2024, Ephemeral Mongo supports only MongoDB 6.0, which is compatible only with Ubuntu 22.04 (https://www.mongodb.com/docs/v6.0/tutorial/install-mongodb-on-ubuntu/)
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -15,10 +16,6 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-dotnet@v4
-
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: "6.0.x"
 
       - run: ./Build.ps1
         shell: pwsh


### PR DESCRIPTION
## Description of changes

Porting the changes already made [to the CI workflow](https://github.com/workleap/wl-extensions-mongo/blob/1.12.0/.github/workflows/ci.yml#L18-L19) to the publish workflow.

Ubuntu-latest is now 24.04, and it doesn't support the provided MongoDB version from EphemeralMongo anymore. For now, target Ubuntu 22.04 specifically.

## Breaking changes

N/A.

## Additional checks

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
