### PR TITLE
Adding support for '_' character value in MongoCollectionAttribute name regular expression

### DIFF
--- a/src/Workleap.Extensions.Mongo.Abstractions/MongoCollectionAttribute.cs
+++ b/src/Workleap.Extensions.Mongo.Abstractions/MongoCollectionAttribute.cs
@@ -5,7 +5,7 @@ namespace Workleap.Extensions.Mongo;
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class MongoCollectionAttribute : Attribute
 {
-    private static readonly Regex ValidNameRegex = new Regex("^[a-zA-Z][a-zA-Z0-9]{0,63}$", RegexOptions.Compiled);
+    private static readonly Regex ValidNameRegex = new Regex("^[a-zA-Z][a-zA-Z0-9_]{0,63}$", RegexOptions.Compiled);
 
     public MongoCollectionAttribute(string name)
     {

--- a/src/Workleap.Extensions.Mongo.Tests/MongoCollectionAttributeTests.cs
+++ b/src/Workleap.Extensions.Mongo.Tests/MongoCollectionAttributeTests.cs
@@ -23,6 +23,8 @@ public class MongoCollectionAttributeTests : BaseUnitTest
     [Theory]
     [InlineData("4SalesTakes")]
     [InlineData("sales-takes")]
+    [InlineData("Sales^Takes")]
+    [InlineData("Sales$Takes")]
     [InlineData("sale$Taxes")]
     public void Attribute_Throws_Given_Invalid_CollectionName(string collectionName)
     {

--- a/src/Workleap.Extensions.Mongo.Tests/MongoCollectionAttributeTests.cs
+++ b/src/Workleap.Extensions.Mongo.Tests/MongoCollectionAttributeTests.cs
@@ -1,4 +1,4 @@
-﻿using Workleap.Extensions.Xunit;
+using Workleap.Extensions.Xunit;
 
 namespace Workleap.Extensions.Mongo.Tests;
 
@@ -12,6 +12,7 @@ public class MongoCollectionAttributeTests : BaseUnitTest
     [InlineData("SalesTaxes")]
     [InlineData("salesTaxes")]
     [InlineData("S4lesTakes")]
+    [InlineData("sales_takes")]
     [InlineData("SalesTakes4")]
     public void Attribute_Ok_Given_Valid_CollectionName(string collectionName)
     {
@@ -22,7 +23,6 @@ public class MongoCollectionAttributeTests : BaseUnitTest
     [Theory]
     [InlineData("4SalesTakes")]
     [InlineData("sales-takes")]
-    [InlineData("sales_takes")]
     [InlineData("sale$Taxes")]
     public void Attribute_Throws_Given_Invalid_CollectionName(string collectionName)
     {


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
Updating the `MongoCollectionAttribute`'s collection name regular expression to support `_` characters for collection names.
## Breaking changes
None

## Additional checks
- [x] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
